### PR TITLE
Skip events when HaProxy connection refused.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Avoid high CPU load problem when connection to HaProxy fails
+  by skipping events. [jone]
 
 
 1.0.0 (2016-09-30)

--- a/supervisor_haproxy/exceptions.py
+++ b/supervisor_haproxy/exceptions.py
@@ -1,0 +1,9 @@
+
+
+class HaProxyConnectionRefused(Exception):
+    """This exception indicates that the haproxy stats socked connection was
+    refused.
+    """
+
+    def __init__(self, exception):
+        super(HaProxyConnectionRefused, self).__init__(*exception.args)

--- a/supervisor_haproxy/haproxy_control.py
+++ b/supervisor_haproxy/haproxy_control.py
@@ -1,5 +1,7 @@
 from contextlib import contextmanager
+from supervisor_haproxy.exceptions import HaProxyConnectionRefused
 import csv
+import errno
 import socket
 
 
@@ -66,7 +68,14 @@ class HaProxyControl(object):
     @contextmanager
     def connect(self):
         sock = socket.socket(self.sock_family, socket.SOCK_STREAM)
-        sock.connect(self.sock_address)
+        try:
+            sock.connect(self.sock_address)
+        except socket.error, exc:
+            if exc.errno == errno.ECONNREFUSED:
+                raise HaProxyConnectionRefused(exc)
+            else:
+                raise
+
         try:
             yield sock
         finally:

--- a/supervisor_haproxy/tests/haproxy_control.py
+++ b/supervisor_haproxy/tests/haproxy_control.py
@@ -1,6 +1,8 @@
+from supervisor_haproxy.exceptions import HaProxyConnectionRefused
 from supervisor_haproxy.haproxy_control import STATUS_DRAIN
 from supervisor_haproxy.haproxy_control import STATUS_MAINT
 from supervisor_haproxy.haproxy_control import STATUS_READY
+import errno
 import socket
 
 
@@ -20,7 +22,8 @@ class HaProxyControlMock(object):
 
     def set_server_status(self, backend, server_name, state):
         if self.refuse_connection:
-            raise socket.error(61, 'Connection refused')
+            raise HaProxyConnectionRefused(
+                socket.error(errno.ECONNREFUSED, 'Connection refused'))
 
         valid_states = (STATUS_READY, STATUS_DRAIN, STATUS_MAINT)
         if state not in valid_states:

--- a/supervisor_haproxy/tests/test_haproxy_control.py
+++ b/supervisor_haproxy/tests/test_haproxy_control.py
@@ -1,3 +1,4 @@
+from supervisor_haproxy.exceptions import HaProxyConnectionRefused
 from supervisor_haproxy.haproxy_control import HaProxyControl
 from supervisor_haproxy.haproxy_control import STATUS_DRAIN
 from supervisor_haproxy.haproxy_control import STATUS_MAINT
@@ -38,6 +39,15 @@ class TestHaProxyControl(unittest.TestCase):
         self.assertEqual(STATUS_MAINT, self.control.get_server_status('A', 'A1'))
         self.control.set_server_status('A', 'A1', STATUS_READY)
         self.assertEqual(STATUS_UP, self.control.get_server_status('A', 'A1'))
+
+    def test_connection_error_is_wrapped(self):
+        # no haproxy running at port 9903
+        control = HaProxyControl('tcp://127.0.0.1:9903')
+        with self.assertRaises(HaProxyConnectionRefused) as cm:
+            control.set_server_status('A', 'A1', STATUS_MAINT)
+
+        self.assertEquals('Connection refused',
+                          cm.exception.args[1])
 
 
 if __name__ == '__main__':

--- a/supervisor_haproxy/tests/test_haproxy_event_listener.py
+++ b/supervisor_haproxy/tests/test_haproxy_event_listener.py
@@ -18,6 +18,8 @@ class TestHaProxyEventListener(TestCase):
 
     def setUp(self):
         self.haproxy_control = HaProxyControlMock()
+        self.event_listener = None
+        self.maxDiff = None
 
     @freeze_time('2016-09-14 10:45:30')
     def test_receive_PROCESS_STATE_EXITED(self):
@@ -93,7 +95,6 @@ class TestHaProxyEventListener(TestCase):
 
     @freeze_time('2016-09-14 11:20:30')
     def test_fail_when_haproxy_control_cannot_connect(self):
-        self.maxDiff = None
         self.haproxy_control.refuse_connection = True
         self.assertEqual(
             {'stdout': 'RESULT 4\nFAIL',
@@ -101,13 +102,83 @@ class TestHaProxyEventListener(TestCase):
                         ' Received PROCESS_STATE_EXITED (from RUNNING)'
                         ' for instance2,'
                         ' sending MAINT for plone04/plone0402.\n'
-                        "ERROR: error(61, 'Connection refused')\n")},
+                        "ERROR: connection to HaProxy stats socket refused\n")},
             self.run_listener(
                 'eventname:PROCESS_STATE_EXITED',
                 'expected:1 processname:instance2 groupname:bar'
                 ' from_state:RUNNING pid:1',
                 programs=[INSTANCE1, INSTANCE2]))
         self.assertEqual([], self.haproxy_control.calls)
+
+    def test_retry_on_failure_then_skip_events(self):
+        # When HaProxy is not reachable, events would stack up and generate
+        # high load because the events are never resolved.
+        # But it could happen that a single connection cannot be established,
+        # because of network issues or a restarting service or another reason.
+
+        # In order to avoid high load the event listener returns FAIL for the
+        # first few failing events, so that the main supervisor process will
+        # requeue them.
+        # If all events are failing, the event listener is set into skpping
+        # state for some time, where it always returns OK and drops all events,
+        # in order to protect from high load.
+        self.haproxy_control.refuse_connection = True
+
+        log_receive = (' Received PROCESS_STATE_EXITED (from RUNNING)'
+                       ' for instance2,'
+                       ' sending MAINT for plone04/plone0402.\n')
+
+        failure = {
+            'stdout': 'RESULT 4\nFAIL',
+            'stderr': (log_receive +
+                       'ERROR: connection to HaProxy stats socket refused\n')}
+
+        skip_start = {
+            'stdout': 'RESULT 2\nOK',
+            'stderr': (log_receive +
+                       'WARNING: too many connections were refused, therefore'
+                       ' this and all future events will be skipped unhandled'
+                       ' for the next 60 seconds.\n')}
+
+        skip_continue = {
+            'stdout': 'RESULT 2\nOK',
+            'stderr': (log_receive +
+                       'WARNING: skipping event handling because too many'
+                       ' connections were refused previously.\n')}
+
+        failure_resume = {
+            'stdout': 'RESULT 4\nFAIL',
+            'stderr': (log_receive +
+                       'WARNING: resuming event handling.\n'
+                       'ERROR: connection to HaProxy stats socket refused\n')}
+
+        def run_listener():
+            result = self.run_listener(
+                'eventname:PROCESS_STATE_EXITED',
+                'expected:1 processname:instance2 groupname:bar'
+                ' from_state:RUNNING pid:1',
+                programs=[INSTANCE1, INSTANCE2])
+            # remove timestamp so that assertions get easier
+            result['stderr'] = result['stderr'][19:]
+            return result
+
+        with freeze_time('2016-01-01 01:00:00'):
+            self.assertEqual(failure, run_listener())
+            self.assertEqual(failure, run_listener())
+            self.assertEqual(failure, run_listener())
+            self.assertEqual(failure, run_listener())
+            # after 4 failures skip events for one minute ..
+            self.assertEqual(skip_start, run_listener())
+            self.assertEqual(skip_continue, run_listener())
+
+        # .. then start trying to connect again
+        with freeze_time('2016-01-01 01:01:01'):
+            self.assertEqual(failure_resume, run_listener())
+            self.assertEqual(failure, run_listener())
+            self.assertEqual(failure, run_listener())
+            self.assertEqual(failure, run_listener())
+            self.assertEqual(skip_start, run_listener())
+            self.assertEqual(skip_continue, run_listener())
 
     def test_ignore_TICK_60_event(self):
         self.assertEqual(
@@ -119,17 +190,19 @@ class TestHaProxyEventListener(TestCase):
         self.assertEqual([], self.haproxy_control.calls)
 
     def run_listener(self, header, body, programs=None):
-        listener = HaProxyEventListener(programs or [],
-                                        haproxy_control=self.haproxy_control)
+        if self.event_listener is None:
+            self.event_listener = HaProxyEventListener(
+                programs or [],
+                haproxy_control=self.haproxy_control)
 
         header = '{} len:{}\n'.format(header, len(body))
-        listener.stdin = StringIO(header + body)
-        listener.stdout = StringIO()
-        listener.stderr = StringIO()
-        listener.runforever(test=True)
-        listener.stdout.seek(0)
-        listener.stderr.seek(0)
+        self.event_listener.stdin = StringIO(header + body)
+        self.event_listener.stdout = StringIO()
+        self.event_listener.stderr = StringIO()
+        self.event_listener.runforever(test=True)
+        self.event_listener.stdout.seek(0)
+        self.event_listener.stderr.seek(0)
 
-        self.assertEquals('READY\n', listener.stdout.read(6))
-        return {'stdout': listener.stdout.read(),
-                'stderr': listener.stderr.read()}
+        self.assertEquals('READY\n', self.event_listener.stdout.read(6))
+        return {'stdout': self.event_listener.stdout.read(),
+                'stderr': self.event_listener.stderr.read()}


### PR DESCRIPTION
When the HaProxy stats socket is not reachable and results in a refused connection, events can pile up and lead to a high load of the supervisor and the eventlistener processes.

Reasons for this situation could be that HaProxy is not running at all, the stats socket is configured inproperly, or the event listener is not configured correctly (e.g. not on the same server).

In order to avoid generating high load a threshold is introduced: only the first 4 consecutive refused connections are responeded with a FAIL to supervisor (which requeues the event), then the eventlistener starts dropping events and responding with OK without even trying to send them to the HaProxy stats socket.

After a timeout of one minute, where everything is dropped, the eventlistener will retry to send events.

With this approach we are no longer generating high load when the HaProxy is never reachable, but when a single connection cannot be established because of a temporary problem (e.g. network instability), the event requeued and retried.

---

I could reproduce the problem in a VM by not installing a HaProxy at all and restarting an instance and waiting a bit.
With installing this branch I did no longer get high load, therefore the issue can be considered fixed.

Test script:
```sh
#!/usr/bin/env sh
/home/zope/stop.sh
sleep 3
/home/zope/haproxy-supervisord.local/demo.web/bin/supervisord
sleep 20
/home/zope/haproxy-supervisord.local/demo.web/bin/supervisorctl restart instance1 instance2
top -U zope -o 'TIME+'
```

---

Closes #4 